### PR TITLE
Updates: ipv6 and minor changes

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ replace sigs.k8s.io/cluster-api => sigs.k8s.io/cluster-api v1.7.0
 
 require (
 	github.com/c-robinson/iplib/v2 v2.0.5
-	github.com/openshift-splat-team/vsphere-capacity-manager v0.0.0-20240529212609-11119e016d95
+	github.com/openshift-splat-team/vsphere-capacity-manager v0.0.0-20240820152614-6bad54a3d5c8
 	github.com/openshift/api v0.0.0-20240502183942-42506f3fcd01
 	github.com/softlayer/softlayer-go v1.1.3
 	github.com/spf13/cobra v1.8.0

--- a/go.sum
+++ b/go.sum
@@ -86,8 +86,8 @@ github.com/onsi/ginkgo/v2 v2.17.1 h1:V++EzdbhI4ZV4ev0UTIj0PzhzOcReJFyJaLjtSF55M8
 github.com/onsi/ginkgo/v2 v2.17.1/go.mod h1:llBI3WDLL9Z6taip6f33H76YcWtJv+7R3HigUjbIBOs=
 github.com/onsi/gomega v1.33.0 h1:snPCflnZrpMsy94p4lXVEkHo12lmPnc3vY5XBbreexE=
 github.com/onsi/gomega v1.33.0/go.mod h1:+925n5YtiFsLzzafLUHzVMBpvvRAzrydIBiSIxjX3wY=
-github.com/openshift-splat-team/vsphere-capacity-manager v0.0.0-20240529212609-11119e016d95 h1:Km3O3AcsV1vbaFEzp+6qM5rzYJPXIFqRRvm8rAgK1BU=
-github.com/openshift-splat-team/vsphere-capacity-manager v0.0.0-20240529212609-11119e016d95/go.mod h1:CPIfgNIv+OgUa9yith8XrOKy6PkAXomU2PXbPXFBlMU=
+github.com/openshift-splat-team/vsphere-capacity-manager v0.0.0-20240820152614-6bad54a3d5c8 h1:qnKxJWCuQ8guE6mLysQAjEpJahE4frJcUQXLKBNDJb8=
+github.com/openshift-splat-team/vsphere-capacity-manager v0.0.0-20240820152614-6bad54a3d5c8/go.mod h1:CPIfgNIv+OgUa9yith8XrOKy6PkAXomU2PXbPXFBlMU=
 github.com/openshift/api v0.0.0-20240502183942-42506f3fcd01 h1:qStvZckKR5QT0qOdYsqNHFWdUrJDUL8b3BLAGS/CGPo=
 github.com/openshift/api v0.0.0-20240502183942-42506f3fcd01/go.mod h1:CxgbWAlvu2iQB0UmKTtRu1YfepRg1/vJ64n2DlIEVz4=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=

--- a/pkg/ibmcloud/objects.go
+++ b/pkg/ibmcloud/objects.go
@@ -4,12 +4,104 @@ import (
 	"context"
 	"fmt"
 	"net"
+	"strings"
 
 	"github.com/softlayer/softlayer-go/datatypes"
 )
 
+/*
+{
+    "broadcastAddress": "",
+    "cidr": 64,
+    "datacenter": {
+        "id": 1854795,
+        "locationStatus": {
+            "id": 2,
+            "status": "Active"
+        },
+        "longName": "Dallas 12",
+        "name": "dal12",
+        "statusId": 2
+    },
+    "gateway": "2607:f0d0:1f01:0022:0000:0000:0000:0001",
+    "id": 1388317,
+    "ipAddresses": [
+        {
+            "id": 203902761,
+            "ipAddress": "2607:f0d0:1f01:0022:0000:0000:0000:0000"
+        },
+        {
+            "id": 203902763,
+            "ipAddress": "2607:f0d0:1f01:0022:0000:0000:0000:0001"
+        },
+        {
+            "id": 203902765,
+            "ipAddress": "2607:f0d0:1f01:0022:0000:0000:0000:0002"
+        },
+        {
+            "id": 203902767,
+            "ipAddress": "2607:f0d0:1f01:0022:0000:0000:0000:0003"
+        },
+        {
+            "id": 203902769,
+            "ipAddress": "2607:f0d0:1f01:0022:0000:0000:0000:0004"
+        },
+        {
+            "id": 203902771,
+            "ipAddress": "2607:f0d0:1f01:0022:0000:0000:0000:0005"
+        },
+        {
+            "id": 203902773,
+            "ipAddress": "2607:f0d0:1f01:0022:0000:0000:0000:0006"
+        },
+        {
+            "id": 203902545,
+            "ipAddress": "2607:f0d0:1f01:0022:ffff:ffff:ffff:ff7e",
+            "note": "Reserved for HSRP."
+        },
+        {
+            "id": 203902543,
+            "ipAddress": "2607:f0d0:1f01:0022:ffff:ffff:ffff:ff7f",
+            "note": "Reserved for HSRP."
+        }
+    ],
+    "isCustomerOwned": false,
+    "isCustomerRoutable": true,
+    "modifyDate": "2023-08-23T09:43:16-06:00",
+    "netmask": "ffff:ffff:ffff:ffff:0000:0000:0000:0000",
+    "networkIdentifier": "2607:f0d0:1f01:0022:0000:0000:0000:0000",
+    "networkVlan": {
+        "accountId": 2626524,
+        "fullyQualifiedName": "dal12.fcr01.853",
+        "id": 3355087,
+        "modifyDate": "2024-07-12T09:14:25-06:00",
+        "name": "ipv6-devqe-segment",
+        "networkSpace": "PUBLIC",
+        "primarySubnetId": 1417493,
+        "vlanNumber": 853
+    },
+    "networkVlanId": 3355087,
+    "note": "ipv6 vms",
+    "sortOrder": "5",
+    "subnetType": "SUBNET_ON_VLAN",
+    "tagReferences": [
+        {
+            "id": 1793811832,
+            "resourceTableId": 1388317,
+            "tagId": 5277216,
+            "tagTypeId": 5,
+            "usrRecordId": 10752008
+        }
+    ],
+    "totalIpAddresses": 18446744073709552000,
+    "usableIpAddressCount": 18446744073709552000,
+    "version": 6
+}
+*/
+
 const (
-	vlanSubnetMask = `mask[id,name,vlanNumber,podName,fullyQualifiedName,datacenter[name],subnets[ipAddressCount,gateway,cidr,netmask,networkIdentifier,subnetType,ipAddresses[ipAddress]],primaryRouter[hostname]]`
+	vlanSubnetMask    = `mask[id,name,vlanNumber,podName,fullyQualifiedName,datacenter[name],subnets[ipAddressCount,gateway,cidr,netmask,networkIdentifier,subnetType,ipAddresses[ipAddress]],primaryRouter[hostname],tagReferences[tag[name]]]`
+	networkSubnetMask = `mask[id,cidr,gateway,tagReferences[tag[name]],version]`
 
 	//backup copy before removal of parameters that maybe we don't need to make the config more readable
 	//vlanSubnetMask = `mask[id,name,vlanNumber,podName,fullyQualifiedName,datacenter[name],subnets[id,ipAddressCount,gateway,cidr,netmask,networkIdentifier,subnetType,ipAddresses[ipAddress,isNetwork,isBroadcast,isGateway]],primaryRouter[hostname]]`
@@ -22,6 +114,36 @@ type VCenterLocation struct {
 	VlanNumber            *int
 
 	IPAddress net.IP
+}
+
+func (m *Metadata) GetSubnetsByTag(account, datacenterName, podName, tag string) (*[]datatypes.Network_Subnet, error) {
+	_, err := m.Session(context.TODO(), account)
+	if err != nil {
+		return nil, err
+	}
+
+	if m.sessions[account].SubnetsCache == nil || len(*m.sessions[account].SubnetsCache) == 0 {
+		subnets, err := m.sessions[account].AccountSession.Mask(networkSubnetMask).GetSubnets()
+		if err != nil {
+			return nil, err
+		}
+
+		m.sessions[account].SubnetsCache = &subnets
+	}
+
+	taggedSubnets := make([]datatypes.Network_Subnet, 0, len(*m.sessions[account].SubnetsCache))
+
+	// I am pretty sure there is a way to do this by the api but /shrug this seems easier at the moment
+
+	for _, s := range *m.sessions[account].SubnetsCache {
+		for _, tagRef := range s.TagReferences {
+			if strings.Contains(*tagRef.Tag.Name, tag) {
+				taggedSubnets = append(taggedSubnets, s)
+			}
+		}
+	}
+
+	return &taggedSubnets, nil
 }
 
 func (m *Metadata) GetVlanSubnets(account, datacenterName, podName string) (*[]datatypes.Network_Vlan, error) {

--- a/pkg/ibmcloud/session.go
+++ b/pkg/ibmcloud/session.go
@@ -19,6 +19,7 @@ type SoftlayerSession struct {
 	AccountSession services.Account
 
 	NetworkVlansCache *[]datatypes.Network_Vlan
+	SubnetsCache      *[]datatypes.Network_Subnet
 }
 
 type Metadata struct {

--- a/vendor/github.com/openshift-splat-team/vsphere-capacity-manager/pkg/apis/vspherecapacitymanager.splat.io/v1/leases_types.go
+++ b/vendor/github.com/openshift-splat-team/vsphere-capacity-manager/pkg/apis/vspherecapacitymanager.splat.io/v1/leases_types.go
@@ -5,10 +5,16 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
+type NetworkType string
+
 const (
-	LeaseKind      = "Lease"
-	APIGroupName   = "vsphere-capacity-manager.splat-team.io"
-	LeaseFinalizer = "vsphere-capacity-manager.splat-team.io/lease-finalizer"
+	LeaseKind               = "Lease"
+	APIGroupName            = "vsphere-capacity-manager.splat-team.io"
+	LeaseFinalizer          = "vsphere-capacity-manager.splat-team.io/lease-finalizer"
+	LeaseNamespace          = "vsphere-capacity-manager.splat-team.io/lease-namespace"
+	NetworkTypeDisconnected = NetworkType("disconnected")
+	NetworkTypeSingleTenant = NetworkType("single-tenant")
+	NetworkTypeMultiTenant  = NetworkType("multi-tenant")
 )
 
 // +genclient
@@ -46,6 +52,17 @@ type LeaseSpec struct {
 	// pool
 	// +optional
 	RequiredPool string `json:"required-pool,omitempty"`
+
+	// NetworkType defines the type of network required by the lease.
+	// by default, all networks are treated as single-tenant. single-tenant networks
+	// are only used by one CI jobs.  multi-tenant networks reside on a
+	// VLAN which may be used by multiple jobs.  disconnected networks aren't yet
+	// supported.
+	// +kubebuilder:validation:Enum="";disconnected;single-tenant;multi-tenant
+	// +kubebuilder:default=single-tenant
+	// +optional
+	NetworkType NetworkType `json:"network-type"`
+
 	// BoskosLeaseID is the ID of the lease in Boskos associated with this lease
 	// +optional
 	BoskosLeaseID string `json:"boskos-lease-id,omitempty"`

--- a/vendor/github.com/openshift-splat-team/vsphere-capacity-manager/pkg/apis/vspherecapacitymanager.splat.io/v1/network_types.go
+++ b/vendor/github.com/openshift-splat-team/vsphere-capacity-manager/pkg/apis/vspherecapacitymanager.splat.io/v1/network_types.go
@@ -8,6 +8,7 @@ const (
 	NETWORKS_LAST_LEASE_UPDATE_ANNOTATION = "vspherecapacitymanager.splat.io/last-network-update"
 	NetworkFinalizer                      = "vsphere-capacity-manager.splat-team.io/network-finalizer"
 	NetworkKind                           = "Network"
+	NetworkTypeLabel                      = "vsphere-capacity-manager.splat-team.io/network-type"
 )
 
 // +genclient

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -102,7 +102,7 @@ github.com/modern-go/reflect2
 # github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822
 ## explicit
 github.com/munnerz/goautoneg
-# github.com/openshift-splat-team/vsphere-capacity-manager v0.0.0-20240529212609-11119e016d95
+# github.com/openshift-splat-team/vsphere-capacity-manager v0.0.0-20240820152614-6bad54a3d5c8
 ## explicit; go 1.22.0
 github.com/openshift-splat-team/vsphere-capacity-manager/pkg/apis/vspherecapacitymanager.splat.io/v1
 # github.com/openshift/api v0.0.0-20240502183942-42506f3fcd01


### PR DESCRIPTION
- Make sure object names are compliant with kube - ToLower()
- Readd PrimaryRouterHostname
- Change vlanId to strconv.Itoa runes was messing up conversion
- Add public ipv6 support with subnet tags